### PR TITLE
Add websocket RPC info to network details in supported languages

### DIFF
--- a/docs/general-info/network-details.md
+++ b/docs/general-info/network-details.md
@@ -20,6 +20,7 @@ import AddToMetaMask from '@site/src/components/AddToMetaMask';
 | **Currency Symbol** | ETH                                       |
 | **Block Explorer**  | https://sepoliascan.status.network       |
 | **Bridge**          | https://bridge.status.network            |
+| **WebSocket RPC**   | Get in touch with us on [Telegram](https://t.me/statusl2) to get a websocket RPC |
 
 <AddToMetaMask />
 <div style={{height: '2rem'}} />

--- a/i18n/ja/docusaurus-plugin-content-docs/current/general-info/network-details.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/general-info/network-details.md
@@ -10,6 +10,7 @@
 | **通貨シンボル**    | ETH                                       |
 | **ブロックエクスプローラー** | https://sepoliascan.status.network       |
 | **ブリッジ**        | https://bridge.status.network            |
+| **WebSocket RPC**   | WebSocket RPCを取得するには[Telegram](https://t.me/statusl2)でお問い合わせください |
 
 これらはStatus Networkテストネットの公式ネットワーク詳細です。これらの詳細は以下の用途に使用できます：
 - ウォレットへのネットワークの追加

--- a/i18n/ko/docusaurus-plugin-content-docs/current/general-info/network-details.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/general-info/network-details.md
@@ -10,6 +10,7 @@
 | **통화 기호**       | ETH                                       |
 | **블록 탐색기**     | https://sepoliascan.status.network       |
 | **브리지**          | https://bridge.status.network            |
+| **WebSocket RPC**   | WebSocket RPC를 받으려면 [Telegram](https://t.me/statusl2)으로 문의하세요 |
 
 이것은 Status Network 테스트넷의 공식 네트워크 세부정보입니다. 이 세부정보는 다음과 같은 용도로 사용할 수 있습니다:
 - 지갑에 네트워크 추가

--- a/i18n/zh/docusaurus-plugin-content-docs/current/general-info/network-details.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/general-info/network-details.md
@@ -10,6 +10,7 @@
 | **货币符号**        | ETH                                       |
 | **区块浏览器**      | https://sepoliascan.status.network       |
 | **跨链桥**          | https://bridge.status.network            |
+| **WebSocket RPC**   | 请通过 [Telegram](https://t.me/statusl2) 联系我们获取 websocket RPC |
 
 这些是 Status Network 测试网的官方网络详情。您可以使用这些详情来：
 - 将网络添加到您的钱包


### PR DESCRIPTION
- Adds WebSocket RPC information to the Status Network details page
- Updates all internationalized versions (Japanese, Korean, Chinese) with WebSocket RPC details
