### PR TITLE
Add Linea merger documentation and announcement UI

### DIFF
--- a/docs/overview/general-info/network-details.md
+++ b/docs/overview/general-info/network-details.md
@@ -10,8 +10,8 @@ import CopyCell from '@site/src/components/CopyCell';
 
 # Network Details
 
-:::warning Sepolia Testnet Sunset
-The Sepolia-based testnet is subject to be sunsetted by the end of April 2026. Please migrate to the new **Status Network Hoodi Testnet** below. Refer to the [migration guide](https://status-im.notion.site/status-network-sepolia-testnet-deprecation-notice) for more information. 
+:::warning Hoodi Testnet Shutdown — May 15, 2026
+Status Network is merging into the Linea stack. The Hoodi testnet (chain ID 374) — RPC, bridge, and all infrastructure — will be shut down on **May 15, 2026**. If you have testnet ETH on the L2, bridge it back to L1 via [bridge.status.network](https://bridge.status.network) before that date. Balances remaining after shutdown will be unrecoverable. [Read the full announcement](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream).
 :::
 
 ## Status Network Hoodi Testnet

--- a/docs/overview/tokenomics/pre-deposits.md
+++ b/docs/overview/tokenomics/pre-deposits.md
@@ -6,6 +6,10 @@ keywords: [Status Network, pre-deposits, vaults, Aragon, Generic Protocol, Karma
 
 # Pre-Deposits
 
+:::info Status Network × Linea Merger — What this means for vault holders
+Following the [merger of Status Network into Linea](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream), pre-deposit vaults remain fully backed and safe. No action is needed now. When the withdrawal interface opens, you will be able to claim your deposits + accrued yield + liquid SNT/LINEA rewards (from the 20M SNT + 20M LINEA pool) on **Linea Mainnet**. An announcement will be made when withdrawals open.
+:::
+
 Status Network runs a pre-deposit campaign to bootstrap liquidity and early Karma distribution ahead of mainnet. Two distinct vault systems power the campaign:
 
 | Asset(s)                 | Vault provider   | Receipt token | Network          |

--- a/docs/tools/core-infrastructure/bridge.md
+++ b/docs/tools/core-infrastructure/bridge.md
@@ -10,8 +10,8 @@ slug: /tools/core-infrastructure/bridge
 The Status Network bridge allows users to transfer tokens and pass messages between Layer 1 and Status Network (Layer 2). 
 The bridge interface is available at [bridge.status.network](https://bridge.status.network).
 
-:::warning Sepolia Testnet Sunset
-The Sepolia-based testnet is subject to be sunsetted by the end of April 2026. Please migrate to the new **Status Network Hoodi Testnet** below. Refer to the [migration guide](https://status-im.notion.site/status-network-sepolia-testnet-deprecation-notice) for more information. 
+:::warning Hoodi Testnet Shutdown — May 15, 2026
+Status Network is merging into the Linea stack. The Hoodi testnet bridge will be shut down on **May 15, 2026**. Bridge your L2 testnet ETH back to L1 before that date — balances remaining after shutdown will be unrecoverable. [Read the full announcement](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream).
 :::
 
 ## Bridge Contracts

--- a/docs/tools/core-infrastructure/testnet-faucets.md
+++ b/docs/tools/core-infrastructure/testnet-faucets.md
@@ -9,8 +9,8 @@ slug: /tools/core-infrastructure/testnet-faucets
 
 To get started on Status Network testnet, you may need some testnet ETH or test assets.
 
-:::warning Sepolia Testnet Sunset
-The Sepolia-based testnet is subject to be sunsetted by the end of April 2026. Please migrate to the new **Status Network Hoodi Testnet** below. Refer to the [migration guide](https://status-im.notion.site/status-network-sepolia-testnet-deprecation-notice) for more information. 
+:::warning Hoodi Testnet Shutdown — May 15, 2026
+Status Network is merging into the Linea stack. The Hoodi testnet — including faucets, RPC, and bridge — shuts down on **May 15, 2026**. Bridge any testnet ETH back to L1 via [bridge.status.network](https://bridge.status.network) before that date. [Read the full announcement](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream).
 :::
 
 ## Status Network Testnet ETH Faucet
@@ -61,8 +61,8 @@ Status Test Token (STT) is the testnet equivalent of SNT. It is used as a test a
 
 ## Status Network Sepolia Testnet Faucets — Deprecated {#sepolia}
 
-:::warning Sepolia Testnet Sunset
-The Sepolia-based testnet is subject to be sunsetted by the end of April 2026. Please migrate to the new **Status Network Hoodi Testnet** below. Refer to the [migration guide](https://status-im.notion.site/status-network-sepolia-testnet-deprecation-notice) for more information. 
+:::warning Hoodi Testnet Shutdown — May 15, 2026
+Status Network is merging into the Linea stack. The Hoodi testnet — including faucets, RPC, and bridge — shuts down on **May 15, 2026**. Bridge any testnet ETH back to L1 via [bridge.status.network](https://bridge.status.network) before that date. [Read the full announcement](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream).
 :::
 
 ## Support

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -63,6 +63,14 @@ const config: Config = {
 
   themeConfig: {
     image: 'img/sn-social-card.png',
+    announcementBar: {
+      id: 'linea-merger-may-2026',
+      content:
+        '<strong>Status Network is merging into Linea.</strong> Hoodi testnet (chain ID 374) shuts down on <strong>May 15, 2026</strong> — bridge testnet ETH back to L1 before then.<br /><a target="_blank" rel="noopener noreferrer" href="https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream">Read the announcement</a> · <a target="_blank" rel="noopener noreferrer" href="https://bridge.status.network">Open bridge</a>',
+      backgroundColor: '#7140fd',
+      textColor: '#ffffff',
+      isCloseable: true,
+    },
     navbar: {
       title: 'Status Network Docs',
       logo: {

--- a/i18n/ja/code.json
+++ b/i18n/ja/code.json
@@ -1,4 +1,8 @@
 {
+  "theme.announcementBar.lineaMergerMay2026": {
+    "message": "<strong>Status Network は Linea に統合されます。</strong>Hoodi テストネット（チェーン ID <strong>374</strong>）は <strong>2026年5月15日</strong>に停止します <br /> それまでにテストネット ETH を L1 にブリッジしてください。<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream\">発表を読む</a> · <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://bridge.status.network\">ブリッジを開く</a>",
+    "description": "Announcement bar HTML for Status Network merging into Linea and Hoodi testnet shutdown (May 15, 2026)."
+  },
   "theme.ErrorPageContent.title": {
     "message": "エラーが発生しました",
     "description": "The title of the fallback page when the page crashed"
@@ -45,7 +49,7 @@
   },
   "theme.colorToggle.ariaLabel": {
     "message": "ダークモードを切り替える(現在は{mode})",
-    "description": "The ARIA label for the navbar color mode toggle"
+    "description": "The ARIA label for the color mode toggle"
   },
   "theme.colorToggle.ariaLabel.mode.dark": {
     "message": "ダークモード",
@@ -283,7 +287,7 @@
   },
   "theme.SearchPage.algoliaLabel": {
     "message": "Algoliaで検索",
-    "description": "The ARIA label for Algolia mention"
+    "description": "The description label for Algolia mention"
   },
   "theme.SearchPage.noResultsText": {
     "message": "検索結果が見つかりませんでした",
@@ -311,15 +315,15 @@
   },
   "theme.SearchModal.startScreen.noRecentSearchesText": {
     "message": "最近の検索履歴はありません",
-    "description": "The text when no recent searches"
+    "description": "The text when there are no recent searches"
   },
   "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
     "message": "この検索をお気に入りに追加",
-    "description": "The label for save recent search button"
+    "description": "The title for save recent search button"
   },
   "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
     "message": "この検索を履歴から削除",
-    "description": "The label for remove recent search button"
+    "description": "The title for remove recent search button"
   },
   "theme.SearchModal.startScreen.favoriteSearchesTitle": {
     "message": "お気に入り",
@@ -327,63 +331,63 @@
   },
   "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
     "message": "この検索をお気に入りから削除",
-    "description": "The label for remove favorite search button"
+    "description": "The title for remove favorite search button"
   },
   "theme.SearchModal.errorScreen.titleText": {
     "message": "検索結果の取得に失敗しました",
-    "description": "The title for error screen of search modal"
+    "description": "The title for error screen"
   },
   "theme.SearchModal.errorScreen.helpText": {
     "message": "ネットワーク接続を確認してください",
-    "description": "The help text for error screen of search modal"
+    "description": "The help text for error screen"
   },
   "theme.SearchModal.footer.selectText": {
     "message": "選ぶ",
-    "description": "The explanatory text of the action for the enter key"
+    "description": "The select text for footer"
   },
   "theme.SearchModal.footer.selectKeyAriaLabel": {
     "message": "エンターキー",
-    "description": "The ARIA label for the Enter key button that makes the selection"
+    "description": "The ARIA label for select key in footer"
   },
   "theme.SearchModal.footer.navigateText": {
     "message": "移動",
-    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+    "description": "The navigate text for footer"
   },
   "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
     "message": "上矢印キー",
-    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+    "description": "The ARIA label for navigate up key in footer"
   },
   "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
     "message": "下矢印キー",
-    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+    "description": "The ARIA label for navigate down key in footer"
   },
   "theme.SearchModal.footer.closeText": {
     "message": "閉じる",
-    "description": "The explanatory text of the action for Escape key"
+    "description": "The close text for footer"
   },
   "theme.SearchModal.footer.closeKeyAriaLabel": {
     "message": "エスケープキー",
-    "description": "The ARIA label for the Escape key button that close the modal"
+    "description": "The ARIA label for close key in footer"
   },
   "theme.SearchModal.footer.searchByText": {
     "message": "検索",
-    "description": "The text explain that the search is making by Algolia"
+    "description": "The 'Powered by' text for footer"
   },
   "theme.SearchModal.noResultsScreen.noResultsText": {
     "message": "見つかりませんでした",
-    "description": "The text explains that there are no results for the following search"
+    "description": "The text when there are no results"
   },
   "theme.SearchModal.noResultsScreen.suggestedQueryText": {
     "message": "次の検索を試す:",
-    "description": "The text for the suggested query when no results are found for the following search"
+    "description": "The text for suggested query"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
     "message": "よりよい検索結果がありますか?",
-    "description": "The text for the question where the user thinks there are missing results"
+    "description": "The text for reporting missing results"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
     "message": "報告する",
-    "description": "The text for the link to report missing results"
+    "description": "The link text for reporting missing results"
   },
   "theme.SearchModal.placeholder": {
     "message": "ドキュメントを検索",
@@ -582,475 +586,477 @@
     "description": "Homepage merger banner secondary action label"
   },
   "ideaCatalog.filter.category": {
-    "message": "カテゴリ",
-    "description": "Filter group label"
+    "message": "カテゴリ"
   },
   "ideaCatalog.filter.statusPrimitives": {
-    "message": "Status固有機能",
-    "description": "Filter group label"
+    "message": "Status固有機能"
   },
   "ideaCatalog.filter.builderProfile": {
-    "message": "ビルダープロフィール",
-    "description": "Filter group label"
+    "message": "ビルダープロフィール"
   },
   "ideaCatalog.filter.difficulty": {
-    "message": "難易度",
-    "description": "Filter group label"
+    "message": "難易度"
   },
   "ideaCatalog.filter.fewerFilters": {
-    "message": "フィルターを閉じる",
-    "description": "Toggle button label"
+    "message": "フィルターを閉じる"
   },
   "ideaCatalog.filter.moreFilters": {
-    "message": "フィルターをもっと見る",
-    "description": "Toggle button label"
+    "message": "フィルターをもっと見る"
   },
   "ideaCatalog.filter.domainExpertise": {
-    "message": "ドメイン専門性",
-    "description": "Filter group label"
+    "message": "ドメイン専門性"
   },
   "ideaCatalog.filter.userSegment": {
-    "message": "ユーザーセグメント",
-    "description": "Filter group label"
+    "message": "ユーザーセグメント"
   },
   "ideaCatalog.filter.capitalRequirement": {
-    "message": "資本要件",
-    "description": "Filter group label"
+    "message": "資本要件"
   },
   "ideaCatalog.status.showing": {
-    "message": "{totalCount}件中{visibleCount}件を表示",
-    "description": "Status text"
+    "message": "{totalCount}件中{visibleCount}件を表示"
   },
   "ideaCatalog.status.clearAll": {
-    "message": "すべてクリア",
-    "description": "Clear all filters button"
+    "message": "すべてクリア"
   },
   "ideaCatalog.card.whyStatus": {
-    "message": "Why Status:",
-    "description": "Card detail label"
+    "message": "Why Status:"
   },
   "ideaCatalog.card.mvpScope": {
-    "message": "MVPスコープ：",
-    "description": "Card detail label"
+    "message": "MVPスコープ："
   },
   "ideaCatalog.card.security": {
-    "message": "セキュリティ",
-    "description": "Card meta badge label"
+    "message": "セキュリティ"
   },
   "ideaCatalog.card.opsBurden": {
-    "message": "運用負担",
-    "description": "Card meta badge label"
+    "message": "運用負担"
   },
   "ideaCatalog.empty.message": {
-    "message": "現在のフィルターに一致するアイデアはありません。",
-    "description": "Empty state message"
+    "message": "現在のフィルターに一致するアイデアはありません。"
   },
   "ideaCatalog.empty.clearAll": {
-    "message": "すべてのフィルターをクリア",
-    "description": "Empty state clear button"
+    "message": "すべてのフィルターをクリア"
   },
   "ideaCatalog.securityCriticality.low": {
-    "message": "低",
-    "description": "Security criticality label"
+    "message": "低"
   },
   "ideaCatalog.securityCriticality.medium": {
-    "message": "中",
-    "description": "Security criticality label"
+    "message": "中"
   },
   "ideaCatalog.securityCriticality.high": {
-    "message": "高",
-    "description": "Security criticality label"
+    "message": "高"
   },
   "ideaCatalog.securityCriticality.critical": {
-    "message": "重大",
-    "description": "Security criticality label"
+    "message": "重大"
   },
   "ideaCatalog.opsBurden.low": {
-    "message": "低",
-    "description": "Ops burden label"
+    "message": "低"
   },
   "ideaCatalog.opsBurden.medium": {
-    "message": "中",
-    "description": "Ops burden label"
+    "message": "中"
   },
   "ideaCatalog.opsBurden.high": {
-    "message": "高",
-    "description": "Ops burden label"
+    "message": "高"
   },
   "ideaCatalog.opsBurden.veryHigh": {
-    "message": "非常に高い",
-    "description": "Ops burden label"
+    "message": "非常に高い"
   },
   "ideaCatalog.category.reputation": {
-    "message": "レピュテーション",
-    "description": "Category label"
+    "message": "レピュテーション"
   },
   "ideaCatalog.category.privacy": {
-    "message": "プライバシー",
-    "description": "Category label"
+    "message": "プライバシー"
   },
   "ideaCatalog.category.social": {
-    "message": "ソーシャル",
-    "description": "Category label"
+    "message": "ソーシャル"
   },
   "ideaCatalog.category.games": {
-    "message": "ゲーム",
-    "description": "Category label"
+    "message": "ゲーム"
   },
   "ideaCatalog.category.defi": {
-    "message": "DeFi",
-    "description": "Category label"
+    "message": "DeFi"
   },
   "ideaCatalog.statusPrimitive.gasless": {
-    "message": "ガスレス",
-    "description": "Status primitive label"
+    "message": "ガスレス"
   },
   "ideaCatalog.statusPrimitive.reputation": {
-    "message": "評判",
-    "description": "Status primitive label"
+    "message": "評判"
   },
   "ideaCatalog.statusPrimitive.privacy": {
-    "message": "プライバシー",
-    "description": "Status primitive label"
+    "message": "プライバシー"
   },
   "ideaCatalog.builderProfile.frontendDev": {
-    "message": "Web / アプリ開発",
-    "description": "Builder profile label"
+    "message": "Web / アプリ開発"
   },
   "ideaCatalog.builderProfile.contractDev": {
-    "message": "スマートコントラクト開発",
-    "description": "Builder profile label"
+    "message": "スマートコントラクト開発"
   },
   "ideaCatalog.builderProfile.fullStack": {
-    "message": "フルスタック",
-    "description": "Builder profile label"
+    "message": "フルスタック"
   },
   "ideaCatalog.builderProfile.protocolDev": {
-    "message": "プロトコル / 暗号学",
-    "description": "Builder profile label"
+    "message": "プロトコル / 暗号学"
   },
   "ideaCatalog.difficulty.lowMed": {
-    "message": "低〜中",
-    "description": "Difficulty label"
+    "message": "低〜中"
   },
   "ideaCatalog.difficulty.med": {
-    "message": "中",
-    "description": "Difficulty label"
+    "message": "中"
   },
   "ideaCatalog.difficulty.medHigh": {
-    "message": "中〜高",
-    "description": "Difficulty label"
+    "message": "中〜高"
   },
   "ideaCatalog.difficulty.high": {
-    "message": "高",
-    "description": "Difficulty label"
+    "message": "高"
   },
   "ideaCatalog.userSegment.consumer": {
-    "message": "コンシューマー",
-    "description": "User segment label"
+    "message": "コンシューマー"
   },
   "ideaCatalog.userSegment.communityCreator": {
-    "message": "コミュニティ/クリエイター",
-    "description": "User segment label"
+    "message": "コミュニティ/クリエイター"
   },
   "ideaCatalog.userSegment.daoOrgOps": {
-    "message": "DAO/組織運営",
-    "description": "User segment label"
+    "message": "DAO/組織運営"
   },
   "ideaCatalog.userSegment.traderDefi": {
-    "message": "トレーダー/DeFi",
-    "description": "User segment label"
+    "message": "トレーダー/DeFi"
   },
   "ideaCatalog.domainExpertise.communityDesign": {
-    "message": "コミュニティデザイン",
-    "description": "Domain expertise label"
+    "message": "コミュニティデザイン"
   },
   "ideaCatalog.domainExpertise.defiMechanisms": {
-    "message": "DeFiメカニズム",
-    "description": "Domain expertise label"
+    "message": "DeFiメカニズム"
   },
   "ideaCatalog.domainExpertise.privacy": {
-    "message": "プライバシー",
-    "description": "Domain expertise label"
+    "message": "プライバシー"
   },
   "ideaCatalog.domainExpertise.paymentsFinops": {
-    "message": "決済/FinOps",
-    "description": "Domain expertise label"
+    "message": "決済/FinOps"
   },
   "ideaCatalog.domainExpertise.consumerProduct": {
-    "message": "コンシューマープロダクト",
-    "description": "Domain expertise label"
+    "message": "コンシューマープロダクト"
   },
   "ideaCatalog.capitalReq.none": {
-    "message": "不要",
-    "description": "Capital requirement label"
+    "message": "不要"
   },
   "ideaCatalog.capitalReq.operatingTreasury": {
-    "message": "運用資金",
-    "description": "Capital requirement label"
+    "message": "運用資金"
   },
   "ideaCatalog.capitalReq.seedLiquidity": {
-    "message": "シード流動性",
-    "description": "Capital requirement label"
+    "message": "シード流動性"
   },
   "ideaCatalog.capitalReq.deepLiquidity": {
-    "message": "深い流動性",
-    "description": "Capital requirement label"
+    "message": "深い流動性"
   },
   "ideaCatalog.idea.karmaGatedAccess.title": {
-    "message": "Karmaゲート付きコンテンツフィード",
-    "description": "Idea title"
+    "message": "Karmaゲート付きコンテンツフィード"
   },
   "ideaCatalog.idea.karmaGatedAccess.what": {
-    "message": "クリエイターが最小Karmaティアを満たすフォロワーにのみ表示される投稿を公開するソーシャルフィード。Substackとオンチェーンレピュテーションの融合。",
-    "description": "Idea what"
+    "message": "クリエイターが最小Karmaティアを満たすフォロワーにのみ表示される投稿を公開するソーシャルフィード。Substackとオンチェーンレピュテーションの融合。"
   },
   "ideaCatalog.idea.karmaGatedAccess.whyStatus": {
-    "message": "Karmaティアはオンチェーンで解決されるため、アクセス制御はトラストレス。サブスクリプション課金なし、プラットフォームロックインなし、Sybil耐性を設計。",
-    "description": "Idea whyStatus"
+    "message": "Karmaティアはオンチェーンで解決されるため、アクセス制御はトラストレス。サブスクリプション課金なし、プラットフォームロックインなし、Sybil耐性を設計。"
   },
   "ideaCatalog.idea.karmaGatedAccess.mvp": {
-    "message": "公開＋ゲート付き投稿のあるフィード、ティアチェックミドルウェア（オプションでオンチェーン）、Karmaティア別のオーディエンス内訳を表示するクリエイターダッシュボード。",
-    "description": "Idea mvp"
+    "message": "公開＋ゲート付き投稿のあるフィード、ティアチェックミドルウェア（オプションでオンチェーン）、Karmaティア別のオーディエンス内訳を表示するクリエイターダッシュボード。"
   },
   "ideaCatalog.idea.karmaLiquidityProtocol.title": {
-    "message": "Karmaブースト付きイールドボールト",
-    "description": "Idea title"
+    "message": "Karmaブースト付きイールドボールト"
   },
   "ideaCatalog.idea.karmaLiquidityProtocol.what": {
-    "message": "より高いKarmaティアの預金者がブーストされたAPYを受け取るDeFiボールト。初期サポーターとアクティブ参加者がより良いリターンを得る。",
-    "description": "Idea what"
+    "message": "より高いKarmaティアの預金者がブーストされたAPYを受け取るDeFiボールト。初期サポーターとアクティブ参加者がより良いリターンを得る。"
   },
   "ideaCatalog.idea.karmaLiquidityProtocol.whyStatus": {
-    "message": "ネイティブレピュテーショングラフにより、ボールトはトークン加重投票やオフチェーンの許可リストではなく、実証済みの参加度に基づいて報酬を配分できる。",
-    "description": "Idea whyStatus"
+    "message": "ネイティブレピュテーショングラフにより、ボールトはトークン加重投票やオフチェーンの許可リストではなく、実証済みの参加度に基づいて報酬を配分できる。"
   },
   "ideaCatalog.idea.karmaLiquidityProtocol.mvp": {
-    "message": "2つのイールドティアを持つ単一資産ボールト、預金時のオンチェーンKarmaティア検索、ティア別の実効APYを表示するダッシュボード。",
-    "description": "Idea mvp"
+    "message": "2つのイールドティアを持つ単一資産ボールト、預金時のオンチェーンKarmaティア検索、ティア別の実効APYを表示するダッシュボード。"
   },
   "ideaCatalog.idea.karmaIncentiveMarket.title": {
-    "message": "Karmaバウンティボード",
-    "description": "Idea title"
+    "message": "Karmaバウンティボード"
   },
   "ideaCatalog.idea.karmaIncentiveMarket.what": {
-    "message": "Karma閾値を超えるユーザーのみがタスクを申請できるバウンティマーケットプレイス。プロジェクトチームが作業（バグ報告、翻訳、オンボーディングガイド）を投稿し、認証された貢献者に報酬を支払う。",
-    "description": "Idea what"
+    "message": "Karma閾値を超えるユーザーのみがタスクを申請できるバウンティマーケットプレイス。プロジェクトチームが作業（バグ報告、翻訳、オンボーディングガイド）を投稿し、認証された貢献者に報酬を支払う。"
   },
   "ideaCatalog.idea.karmaIncentiveMarket.whyStatus": {
-    "message": "Karmaゲートによりスパムボットや低品質の提出を排除し、バウンティ発行者は申請者がネットワークに実際の実績を持つことを信頼できる。",
-    "description": "Idea whyStatus"
+    "message": "Karmaゲートによりスパムボットや低品質の提出を排除し、バウンティ発行者は申請者がネットワークに実際の実績を持つことを信頼できる。"
   },
   "ideaCatalog.idea.karmaIncentiveMarket.mvp": {
-    "message": "バウンティ一覧ページ、Karmaゲート付き申請フロー、提出物レビューパネル、承認時のオンチェーン支払い。",
-    "description": "Idea mvp"
+    "message": "バウンティ一覧ページ、Karmaゲート付き申請フロー、提出物レビューパネル、承認時のオンチェーン支払い。"
   },
   "ideaCatalog.idea.karmaDynamicPricing.title": {
-    "message": "Karmaティア付きNFTマーケットプレイス",
-    "description": "Idea title"
+    "message": "Karmaティア付きNFTマーケットプレイス"
   },
   "ideaCatalog.idea.karmaDynamicPricing.what": {
-    "message": "出品者・購入者のKarmaティアに基づいて出品手数料、ロイヤリティ、先行アクセス期間が調整されるNFTマーケットプレイス。信頼された参加者には自動的に有利な条件が適用される。",
-    "description": "Idea what"
+    "message": "出品者・購入者のKarmaティアに基づいて出品手数料、ロイヤリティ、先行アクセス期間が調整されるNFTマーケットプレイス。信頼された参加者には自動的に有利な条件が適用される。"
   },
   "ideaCatalog.idea.karmaDynamicPricing.whyStatus": {
-    "message": "チェックアウト時のオンチェーン tier resolution により、動的価格設定がトラストレスに適用される。クーポンコードもバックエンド許可リストも不要。",
-    "description": "Idea whyStatus"
+    "message": "チェックアウト時のオンチェーン tier resolution により、動的価格設定がトラストレスに適用される。クーポンコードもバックエンド許可リストも不要。"
   },
   "ideaCatalog.idea.karmaDynamicPricing.mvp": {
-    "message": "NFT出品＋購入フロー（ティア付き手数料スケジュール）、チェックアウト時のオンチェーン tier check、購入者ティア別の売上を表示する出品者分析。",
-    "description": "Idea mvp"
+    "message": "NFT出品＋購入フロー（ティア付き手数料スケジュール）、チェックアウト時のオンチェーン tier check、購入者ティア別の売上を表示する出品者分析。"
   },
   "ideaCatalog.idea.stealthAddressPayments.title": {
-    "message": "ステルスアドレス決済",
-    "description": "Idea title"
+    "message": "ステルスアドレス決済"
   },
   "ideaCatalog.idea.stealthAddressPayments.what": {
-    "message": "リンク不可能な支出パスを持つ使い捨て受信アドレス。",
-    "description": "Idea what"
+    "message": "リンク不可能な支出パスを持つ使い捨て受信アドレス。"
   },
   "ideaCatalog.idea.stealthAddressPayments.whyStatus": {
-    "message": "プライバシープリミティブ＋低摩擦トランザクションUX。",
-    "description": "Idea whyStatus"
+    "message": "プライバシープリミティブ＋低摩擦トランザクションUX。"
   },
   "ideaCatalog.idea.stealthAddressPayments.mvp": {
-    "message": "アドレス生成、受信フロー、プライベート支出フロー。",
-    "description": "Idea mvp"
+    "message": "アドレス生成、受信フロー、プライベート支出フロー。"
   },
   "ideaCatalog.idea.privatePayroll.title": {
-    "message": "プライベート給与・貯蓄",
-    "description": "Idea title"
+    "message": "プライベート給与・貯蓄"
   },
   "ideaCatalog.idea.privatePayroll.what": {
-    "message": "残高と受取人を公開しない給与・貯蓄レール。",
-    "description": "Idea what"
+    "message": "残高と受取人を公開しない給与・貯蓄レール。"
   },
   "ideaCatalog.idea.privatePayroll.whyStatus": {
-    "message": "公開台帳が期待に応えられない現実世界のニーズ。",
-    "description": "Idea whyStatus"
+    "message": "公開台帳が期待に応えられない現実世界のニーズ。"
   },
   "ideaCatalog.idea.privatePayroll.mvp": {
-    "message": "雇用主支払いバッチ＋受取人請求＋シールド付きボールト。",
-    "description": "Idea mvp"
+    "message": "雇用主支払いバッチ＋受取人請求＋シールド付きボールト。"
   },
   "ideaCatalog.idea.shieldedMicrotransactions.title": {
-    "message": "シールド付きマイクロ決済 / カードレイヤー",
-    "description": "Idea title"
+    "message": "シールド付きマイクロ決済 / カードレイヤー"
   },
   "ideaCatalog.idea.shieldedMicrotransactions.what": {
-    "message": "金額・参加者を隠した低額決済とサブスクリプション。",
-    "description": "Idea what"
+    "message": "金額・参加者を隠した低額決済とサブスクリプション。"
   },
   "ideaCatalog.idea.shieldedMicrotransactions.whyStatus": {
-    "message": "Gasless相互作用により頻繁な決済が実現可能。",
-    "description": "Idea whyStatus"
+    "message": "Gasless相互作用により頻繁な決済が実現可能。"
   },
   "ideaCatalog.idea.shieldedMicrotransactions.mvp": {
-    "message": "定期認証付きプライベートチップ/サブスクリプションフロー。",
-    "description": "Idea mvp"
+    "message": "定期認証付きプライベートチップ/サブスクリプションフロー。"
   },
   "ideaCatalog.idea.privateLending.title": {
-    "message": "プライベート貸借",
-    "description": "Idea title"
+    "message": "プライベート貸借"
   },
   "ideaCatalog.idea.privateLending.what": {
-    "message": "公開ポジション漏洩を避ける借入・貸出フロー。",
-    "description": "Idea what"
+    "message": "公開ポジション漏洩を避ける借入・貸出フロー。"
   },
   "ideaCatalog.idea.privateLending.whyStatus": {
-    "message": "プライバシー＋Karmaベースの信頼シグナル。",
-    "description": "Idea whyStatus"
+    "message": "プライバシー＋Karmaベースの信頼シグナル。"
   },
   "ideaCatalog.idea.privateLending.mvp": {
-    "message": "1種類の担保、1種類の借入資産、プライベートヘルスチェック。",
-    "description": "Idea mvp"
+    "message": "1種類の担保、1種類の借入資産、プライベートヘルスチェック。"
   },
   "ideaCatalog.idea.privateMultisig.title": {
-    "message": "プライベート多重署名",
-    "description": "Idea title"
+    "message": "プライベート多重署名"
   },
   "ideaCatalog.idea.privateMultisig.what": {
-    "message": "署名者、閾値、取引詳細が隠蔽される多重署名機能。",
-    "description": "Idea what"
+    "message": "署名者、閾値、取引詳細が隠蔽される多重署名機能。"
   },
   "ideaCatalog.idea.privateMultisig.whyStatus": {
-    "message": "プライバシー重視の組織でもオンチェーンで運営可能。",
-    "description": "Idea whyStatus"
+    "message": "プライバシー重視の組織でもオンチェーンで運営可能。"
   },
   "ideaCatalog.idea.privateMultisig.mvp": {
-    "message": "ポリシー設定＋署名フロー＋選択的開示付き実行ログ。",
-    "description": "Idea mvp"
+    "message": "ポリシー設定＋署名フロー＋選択的開示付き実行ログ。"
   },
   "ideaCatalog.idea.socialMiniApp.title": {
-    "message": "Gaslessマイクロブログプラットフォーム",
-    "description": "Idea title"
+    "message": "Gaslessマイクロブログプラットフォーム"
   },
   "ideaCatalog.idea.socialMiniApp.what": {
-    "message": "すべての投稿、返信、いいねがユーザーに無料のオンチェーンアクションとなるTwitter風マイクロブログ。Karmaバッジで信頼された声を可視化。",
-    "description": "Idea what"
+    "message": "すべての投稿、返信、いいねがユーザーに無料のオンチェーンアクションとなるTwitter風マイクロブログ。Karmaバッジで信頼された声を可視化。"
   },
   "ideaCatalog.idea.socialMiniApp.whyStatus": {
-    "message": "Gaslessトランザクションにより投稿・アクションごとの経済が実現可能。Karmaバッジは任意の青チェックシステムを、実際のネットワーク参加に基づくレピュテーションに置き換える。",
-    "description": "Idea whyStatus"
+    "message": "Gaslessトランザクションにより投稿・アクションごとの経済が実現可能。Karmaバッジは任意の青チェックシステムを、実際のネットワーク参加に基づくレピュテーションに置き換える。"
   },
   "ideaCatalog.idea.socialMiniApp.mvp": {
-    "message": "タイムライン、投稿/返信/いいねアクション、Karma信頼バッジ付きユーザープロフィール、基本コンテンツモデレーション。",
-    "description": "Idea mvp"
+    "message": "タイムライン、投稿/返信/いいねアクション、Karma信頼バッジ付きユーザープロフィール、基本コンテンツモデレーション。"
   },
   "ideaCatalog.idea.creatorEconomyToolkit.title": {
-    "message": "ファンパスプラットフォーム",
-    "description": "Idea title"
+    "message": "ファンパスプラットフォーム"
   },
   "ideaCatalog.idea.creatorEconomyToolkit.what": {
-    "message": "クリエイターが限定コンテンツ、グループチャット、IRLイベントアクセスをアンロックする無料デジタルパスをミントするプラットフォーム。ファンはGaslessでパスを収集。",
-    "description": "Idea what"
+    "message": "クリエイターが限定コンテンツ、グループチャット、IRLイベントアクセスをアンロックする無料デジタルパスをミントするプラットフォーム。ファンはGaslessでパスを収集。"
   },
   "ideaCatalog.idea.creatorEconomyToolkit.whyStatus": {
-    "message": "ゼロコストのミントと請求により、コミュニティパスからのペイウォール摩擦を排除。クリエイターはファンにガス代を払わせることなくオーディエンスを拡大できる。",
-    "description": "Idea whyStatus"
+    "message": "ゼロコストのミントと請求により、コミュニティパスからのペイウォール摩擦を排除。クリエイターはファンにガス代を払わせることなくオーディエンスを拡大できる。"
   },
   "ideaCatalog.idea.creatorEconomyToolkit.mvp": {
-    "message": "パスミント付きクリエイターページ、ファン請求フロー、パスゲート付きコンテンツセクション、パス検証によるイベントチェックイン。",
-    "description": "Idea mvp"
+    "message": "パスミント付きクリエイターページ、ファン請求フロー、パスゲート付きコンテンツセクション、パス検証によるイベントチェックイン。"
   },
   "ideaCatalog.idea.communityGovernance.title": {
-    "message": "DAO提案・Karma加重投票アプリ",
-    "description": "Idea title"
+    "message": "DAO提案・Karma加重投票アプリ"
   },
   "ideaCatalog.idea.communityGovernance.what": {
-    "message": "コミュニティメンバーが提案を提出し、Karmaティアに比例した重みで投票するガバナンスアプリ。アクティブな貢献者は受動的なホルダーより大きな声を持つ。",
-    "description": "Idea what"
+    "message": "コミュニティメンバーが提案を提出し、Karmaティアに比例した重みで投票するガバナンスアプリ。アクティブな貢献者は受動的なホルダーより大きな声を持つ。"
   },
   "ideaCatalog.idea.communityGovernance.whyStatus": {
-    "message": "Karma加重投票はトークン蓄積ではなく実際の参加を報酬。Gasless投票はほとんどのDAOで投票率を抑えるコスト障壁を除去。",
-    "description": "Idea whyStatus"
+    "message": "Karma加重投票はトークン蓄積ではなく実際の参加を報酬。Gasless投票はほとんどのDAOで投票率を抑えるコスト障壁を除去。"
   },
   "ideaCatalog.idea.communityGovernance.mvp": {
-    "message": "提案提出フォーム、オンチェーン集計付きKarma加重投票、ティア別参加内訳付き結果ダッシュボード。",
-    "description": "Idea mvp"
+    "message": "提案提出フォーム、オンチェーン集計付きKarma加重投票、ティア別参加内訳付き結果ダッシュボード。"
   },
   "ideaCatalog.idea.onchainStrategyGame.title": {
-    "message": "フォグオブウォー征服ゲーム",
-    "description": "Idea title"
+    "message": "フォグオブウォー征服ゲーム"
   },
   "ideaCatalog.idea.onchainStrategyGame.what": {
-    "message": "部隊の位置がプライベートステートで隠され、すべての移動がGaslessオンチェーントランザクションとなる六角グリッド領土争奪ゲーム。Riskボードゲームに本物のオンチェーンフォグオブウォーを融合。",
-    "description": "Idea what"
+    "message": "部隊の位置がプライベートステートで隠され、すべての移動がGaslessオンチェーントランザクションとなる六角グリッド領土争奪ゲーム。Riskボードゲームに本物のオンチェーンフォグオブウォーを融合。"
   },
   "ideaCatalog.idea.onchainStrategyGame.whyStatus": {
-    "message": "プライバシープリミティブにより真の隠蔽情報（クライアントサイドのフォグのみではない）を実現。Gasless移動により戦略ゲームの迅速な往来が経済的に可能に。",
-    "description": "Idea whyStatus"
+    "message": "プライバシープリミティブにより真の隠蔽情報（クライアントサイドのフォグのみではない）を実現。Gasless移動により戦略ゲームの迅速な往来が経済的に可能に。"
   },
   "ideaCatalog.idea.onchainStrategyGame.mvp": {
-    "message": "フォグオブウォー付き六角マップ、1種類のユニット、プライベート部隊配置、ターン解決、マッチリーダーボード。",
-    "description": "Idea mvp"
+    "message": "フォグオブウォー付き六角マップ、1種類のユニット、プライベート部隊配置、ターン解決、マッチリーダーボード。"
   },
   "ideaCatalog.idea.predictionMarket.title": {
-    "message": "予測市場",
-    "description": "Idea title"
+    "message": "予測市場"
   },
   "ideaCatalog.idea.predictionMarket.what": {
-    "message": "低摩擦のエントリーとプライベート参加者ポジションを持つ市場。",
-    "description": "Idea what"
+    "message": "低摩擦のエントリーとプライベート参加者ポジションを持つ市場。"
   },
   "ideaCatalog.idea.predictionMarket.whyStatus": {
-    "message": "より良い市場参加とコピートレード行動の減少。",
-    "description": "Idea whyStatus"
+    "message": "より良い市場参加とコピートレード行動の減少。"
   },
   "ideaCatalog.idea.predictionMarket.mvp": {
-    "message": "市場作成＋ポジションエントリー＋決済＋基本分析。",
-    "description": "Idea mvp"
+    "message": "市場作成＋ポジションエントリー＋決済＋基本分析。"
   },
   "ideaCatalog.idea.nativeDexCompanion.title": {
-    "message": "Karmaティア付きスワップルーター",
-    "description": "Idea title"
+    "message": "Karmaティア付きスワップルーター"
   },
   "ideaCatalog.idea.nativeDexCompanion.what": {
-    "message": "最良のオンチェーンプールを経由して取引をルーティングし、高Karmaユーザーに手数料削減と優先実行を提供するスワップインターフェース。DEXレイヤーに組み込まれたロイヤルティプログラム。",
-    "description": "Idea what"
+    "message": "最良のオンチェーンプールを経由して取引をルーティングし、高Karmaユーザーに手数料削減と優先実行を提供するスワップインターフェース。DEXレイヤーに組み込まれたロイヤルティプログラム。"
   },
   "ideaCatalog.idea.nativeDexCompanion.whyStatus": {
-    "message": "Karmaティアによりルーターがトラストレスに手数料割引を提供。ネイティブ流動性との緊密な統合により、外部アグリゲーターの依存なしでより良いレートを実現。",
-    "description": "Idea whyStatus"
+    "message": "Karmaティアによりルーターがトラストレスに手数料割引を提供。ネイティブ流動性との緊密な統合により、外部アグリゲーターの依存なしでより良いレートを実現。"
   },
   "ideaCatalog.idea.nativeDexCompanion.mvp": {
-    "message": "ティア付き手数料表示付きトークンスワップUI、Karma対応ルーティングロジック、LPポジションパネル、ティア別の節約手数料を表示する取引履歴。",
-    "description": "Idea mvp"
+    "message": "ティア付き手数料表示付きトークンスワップUI、Karma対応ルーティングロジック、LPポジションパネル、ティア別の節約手数料を表示する取引履歴。"
   },
   "ideaCatalog.idea.publicFundingInterface.title": {
-    "message": "パブリックファンディングインターフェース",
-    "description": "Idea title"
+    "message": "パブリックファンディングインターフェース"
   },
   "ideaCatalog.idea.publicFundingInterface.what": {
-    "message": "エンドツーエンドのgrant発見、提案、投票、追跡ダッシュボード。",
-    "description": "Idea what"
+    "message": "エンドツーエンドのgrant発見、提案、投票、追跡ダッシュボード。"
   },
   "ideaCatalog.idea.publicFundingInterface.whyStatus": {
-    "message": "エコシステム成長フライホイールを直接支援。",
-    "description": "Idea whyStatus"
+    "message": "エコシステム成長フライホイールを直接支援。"
   },
   "ideaCatalog.idea.publicFundingInterface.mvp": {
-    "message": "提案ボード＋投票画面＋grant進捗トラッカー。",
-    "description": "Idea mvp"
+    "message": "提案ボード＋投票画面＋grant進捗トラッカー。"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "システムモード",
+    "description": "The name for the system color mode"
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(opens in new tab)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "Expand the dropdown",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "Collapse the dropdown",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.SearchModal.searchBox.placeholderText": {
+    "message": "ドキュメントを検索",
+    "description": "The placeholder text for the main search input field"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAi": {
+    "message": "別の質問をする...",
+    "description": "The placeholder text when in AI question mode"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAiStreaming": {
+    "message": "回答中...",
+    "description": "The placeholder text for search box when AI is streaming an answer"
+  },
+  "theme.SearchModal.searchBox.enterKeyHint": {
+    "message": "検索",
+    "description": "The hint for the search box enter key text"
+  },
+  "theme.SearchModal.searchBox.enterKeyHintAskAi": {
+    "message": "確定",
+    "description": "The hint for the Ask AI search box enter key text"
+  },
+  "theme.SearchModal.searchBox.searchInputLabel": {
+    "message": "検索",
+    "description": "The ARIA label for search input"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonText": {
+    "message": "キーワード検索に戻る",
+    "description": "The text for back to keyword search button"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonAriaLabel": {
+    "message": "キーワード検索に戻る",
+    "description": "The ARIA label for back to keyword search button"
+  },
+  "theme.SearchModal.startScreen.recentConversationsTitle": {
+    "message": "最近の会話",
+    "description": "The title for recent conversations"
+  },
+  "theme.SearchModal.startScreen.removeRecentConversationButtonTitle": {
+    "message": "この会話を履歴から削除",
+    "description": "The title for remove recent conversation button"
+  },
+  "theme.SearchModal.resultsScreen.askAiPlaceholder": {
+    "message": "AIに質問：",
+    "description": "The placeholder text for Ask AI input"
+  },
+  "theme.SearchModal.askAiScreen.disclaimerText": {
+    "message": "回答はAIによって生成されており、誤りがある可能性があります。必ず内容を確認してください。",
+    "description": "The disclaimer text for AI answers"
+  },
+  "theme.SearchModal.askAiScreen.relatedSourcesText": {
+    "message": "関連ソース",
+    "description": "The text for related sources"
+  },
+  "theme.SearchModal.askAiScreen.thinkingText": {
+    "message": "考え中...",
+    "description": "The text when AI is thinking"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonText": {
+    "message": "コピー",
+    "description": "The text for copy button"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonCopiedText": {
+    "message": "コピーしました！",
+    "description": "The text for copy button when copied"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonTitle": {
+    "message": "コピー",
+    "description": "The title for copy button"
+  },
+  "theme.SearchModal.askAiScreen.likeButtonTitle": {
+    "message": "いいね",
+    "description": "The title for like button"
+  },
+  "theme.SearchModal.askAiScreen.dislikeButtonTitle": {
+    "message": "よくない",
+    "description": "The title for dislike button"
+  },
+  "theme.SearchModal.askAiScreen.thanksForFeedbackText": {
+    "message": "フィードバックありがとうございます！",
+    "description": "The text for thanks for feedback"
+  },
+  "theme.SearchModal.askAiScreen.preToolCallText": {
+    "message": "検索中...",
+    "description": "The text before tool call"
+  },
+  "theme.SearchModal.askAiScreen.duringToolCallText": {
+    "message": "検索中：",
+    "description": "The text during tool call"
+  },
+  "theme.SearchModal.askAiScreen.afterToolCallText": {
+    "message": "検索完了：",
+    "description": "The text after tool call"
+  },
+  "theme.SearchModal.footer.submitQuestionText": {
+    "message": "質問を送信",
+    "description": "The submit question text for footer"
+  },
+  "theme.SearchModal.footer.backToSearchText": {
+    "message": "検索に戻る",
+    "description": "The back to search text for footer"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "この著者による投稿はまだありません。",
+    "description": "The text for authors with 0 blog post"
   }
 }

--- a/i18n/ja/code.json
+++ b/i18n/ja/code.json
@@ -545,6 +545,42 @@
     "message": "ウェブサイト、ソーシャルチャンネル、すべての公式リソースを一か所に",
     "description": "Homepage community card description for official links"
   },
+  "homepage.merger.tag": {
+    "message": "ネットワーク更新",
+    "description": "Homepage merger banner tag/eyebrow"
+  },
+  "homepage.merger.title": {
+    "message": "Status Network が Linea に統合されます",
+    "description": "Homepage merger banner title"
+  },
+  "homepage.merger.subtitle": {
+    "message": "Hoodi テストネット（チェーン ID 374）は 2026 年 5 月 15 日に終了します — RPC およびブリッジを含む全インフラが停止されます。",
+    "description": "Homepage merger banner subtitle"
+  },
+  "homepage.merger.testnet.heading": {
+    "message": "Status Network Hoodi にテストネット ETH をお持ちですか？",
+    "description": "Homepage merger CTA heading for testnet ETH holders"
+  },
+  "homepage.merger.testnet.body": {
+    "message": "5 月 15 日までに bridge.status.network を通じて L2 → L1 へ資産をブリッジしてください。終了後に L2 テストネットに残った残高は回収不可能となります。Hoodi のスナップショットはすでに完了しているため、今出金しても SNT + LINEA 報酬の資格には影響しません。",
+    "description": "Homepage merger CTA body for testnet ETH holders"
+  },
+  "homepage.merger.predeposit.heading": {
+    "message": "プレデポジットボールトに参加されましたか？",
+    "description": "Homepage merger CTA heading for pre-deposit vault holders"
+  },
+  "homepage.merger.predeposit.body": {
+    "message": "現時点では何もする必要はありません。ボールトは完全に安全に保管されています。引き出しインターフェースが開放された際に、Linea メインネット上でデポジット + 累積収益 + SNT/LINEA の流動報酬を請求できます。案内があるまでお待ちください。",
+    "description": "Homepage merger CTA body for pre-deposit vault holders"
+  },
+  "homepage.merger.action.announcement": {
+    "message": "全文を読む",
+    "description": "Homepage merger banner primary action label"
+  },
+  "homepage.merger.action.bridge": {
+    "message": "ブリッジを開く",
+    "description": "Homepage merger banner secondary action label"
+  },
   "ideaCatalog.filter.category": {
     "message": "カテゴリ",
     "description": "Filter group label"

--- a/i18n/ja/docusaurus-plugin-content-docs/current/overview/general-info/network-details.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/overview/general-info/network-details.md
@@ -13,6 +13,10 @@ keywords:
 ---
 # ネットワークの詳細
 
+:::warning Hoodi テストネット終了 — 2026年5月15日
+Status Network は Linea スタックへ統合されます。Hoodi テストネット（チェーン ID 374）の RPC、ブリッジ、関連インフラは **2026年5月15日** に停止します。L2 のテストネット ETH はその日までに [bridge.status.network](https://bridge.status.network) で L1 に戻してください。停止後に残った残高は復元できません。[公式発表を読む](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream)。
+:::
+
 ## Status テストネット
 
 | 名前                | 値                                       |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/overview/tokenomics/pre-deposits.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/overview/tokenomics/pre-deposits.md
@@ -20,6 +20,10 @@ keywords:
 
 # プレデポジット
 
+:::info Status Network × Linea 統合 — ボールト参加者へのご案内
+[Status Network の Linea への統合](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream)後も、プレデポジットボールトは全額担保され安全です。現時点で対応は不要です。引き出し画面が公開されると、**Linea Mainnet** 上で預入金 + 累積利回り + 流動性報酬（2,000万 SNT + 2,000万 LINEA プール）を請求できます。引き出し開始時に改めて告知します。
+:::
+
 Status Networkは、メインネットローンチに先立ち、流動性の確保と初期Karma配布のための事前預入キャンペーンを実施しています。2つの異なるボールトシステムがキャンペーンを支えています：
 
 | 資産                     | ボールト提供者   | 受領トークン | ネットワーク     |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tools/core-infrastructure/bridge.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tools/core-infrastructure/bridge.md
@@ -18,6 +18,10 @@ Hoodi（レイヤー1）と Status Network Hoodi テストネット（レイヤ�
 ブリッジインターフェースは
 [bridge.status.network](https://bridge.status.network) で利用できます。
 
+:::warning Hoodi テストネット終了 — 2026年5月15日
+Status Network は Linea スタックへ統合されます。Hoodi テストネットのブリッジは **2026年5月15日** に停止します。停止前に L2 のテストネット ETH を L1 へ戻してください。停止後に残った残高は復元できません。[公式発表を読む](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream)。
+:::
+
 ## ブリッジコントラクト
 
 ### レイヤー1（Hoodi）

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tools/core-infrastructure/testnet-faucets.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tools/core-infrastructure/testnet-faucets.md
@@ -14,6 +14,10 @@ slug: '/tools/core-infrastructure/testnet-faucets'
 
 Status Network Hoodi テストネットを開始するには、テストネット ETH またはテストアセットが必要になる場合があります。
 
+:::warning Hoodi テストネット終了 — 2026年5月15日
+Status Network は Linea スタックへ統合されます。フォーセット、RPC、ブリッジを含む Hoodi テストネットの全インフラは **2026年5月15日** に停止します。L2 のテストネット ETH はその日までに [bridge.status.network](https://bridge.status.network) で L1 に戻してください。[公式発表を読む](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream)。
+:::
+
 ## Status Network Hoodi テストネット ETH フォーセット
 
 Status Network Hoodi テストネットフォーセットは [faucet.status.network](https://eth.faucet.status.network) で利用できます。

--- a/i18n/ko/code.json
+++ b/i18n/ko/code.json
@@ -545,6 +545,42 @@
     "message": "웹사이트, 소셜 채널, 모든 공식 리소스를 한 곳에서 확인하세요",
     "description": "Homepage community card description for official links"
   },
+  "homepage.merger.tag": {
+    "message": "네트워크 업데이트",
+    "description": "Homepage merger banner tag/eyebrow"
+  },
+  "homepage.merger.title": {
+    "message": "Status Network가 Linea에 합병됩니다",
+    "description": "Homepage merger banner title"
+  },
+  "homepage.merger.subtitle": {
+    "message": "Hoodi 테스트넷(체인 ID 374)은 2026년 5월 15일에 종료됩니다 — RPC 및 브릿지 포함 모든 인프라가 중단됩니다.",
+    "description": "Homepage merger banner subtitle"
+  },
+  "homepage.merger.testnet.heading": {
+    "message": "Status Network Hoodi에 테스트넷 ETH가 있으신가요?",
+    "description": "Homepage merger CTA heading for testnet ETH holders"
+  },
+  "homepage.merger.testnet.body": {
+    "message": "5월 15일 이전에 bridge.status.network를 통해 L2 → L1으로 자산을 이전하세요. 종료 후 L2 테스트넷에 남은 잔액은 복구할 수 없습니다. Hoodi 스냅샷은 이미 완료되었으므로, 지금 출금해도 SNT + LINEA 보상 자격에는 영향이 없습니다.",
+    "description": "Homepage merger CTA body for testnet ETH holders"
+  },
+  "homepage.merger.predeposit.heading": {
+    "message": "사전 예치에 참여하셨나요?",
+    "description": "Homepage merger CTA heading for pre-deposit vault holders"
+  },
+  "homepage.merger.predeposit.body": {
+    "message": "지금은 별도 조치가 필요하지 않습니다. 금고는 안전하게 보관되어 있습니다. 인출 인터페이스가 열리면 Linea 메인넷에서 예치금 + 누적 수익 + SNT/LINEA 유동 보상을 출금할 수 있습니다. 공지를 기다려 주세요.",
+    "description": "Homepage merger CTA body for pre-deposit vault holders"
+  },
+  "homepage.merger.action.announcement": {
+    "message": "전체 공지 읽기",
+    "description": "Homepage merger banner primary action label"
+  },
+  "homepage.merger.action.bridge": {
+    "message": "브릿지 열기",
+    "description": "Homepage merger banner secondary action label"
+  },
   "ideaCatalog.filter.category": {
     "message": "카테고리",
     "description": "Filter group label"

--- a/i18n/ko/code.json
+++ b/i18n/ko/code.json
@@ -1,4 +1,8 @@
 {
+  "theme.announcementBar.lineaMergerMay2026": {
+    "message": "<strong>Status Network가 Linea에 합병됩니다.</strong>Hoodi 테스트넷(체인 ID <strong>374</strong>)은 <strong>2026년 5월 15일</strong>에 종료됩니다 — 그 전에 테스트넷 ETH를 L1으로 브릿지하세요.<br /><a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream\">공지 읽기</a> · <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://bridge.status.network\">브릿지 열기</a>",
+    "description": "Announcement bar HTML for Status Network merging into Linea and Hoodi testnet shutdown (May 15, 2026)."
+  },
   "theme.ErrorPageContent.title": {
     "message": "페이지에 오류가 발생하였습니다.",
     "description": "The title of the fallback page when the page crashed"

--- a/i18n/ko/docusaurus-plugin-content-docs/current/overview/general-info/network-details.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/overview/general-info/network-details.md
@@ -13,6 +13,10 @@ keywords:
 ---
 # 네트워크 세부정보
 
+:::warning Hoodi 테스트넷 종료 — 2026년 5월 15일
+Status Network는 Linea 스택으로 합병됩니다. Hoodi 테스트넷(체인 ID 374)의 RPC, 브릿지 및 모든 인프라는 **2026년 5월 15일**에 종료됩니다. L2 테스트넷 ETH는 그 전에 [bridge.status.network](https://bridge.status.network)에서 L1으로 되돌리세요. 종료 후 남은 잔액은 복구할 수 없습니다. [전체 공지 보기](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream).
+:::
+
 ## Status 테스트넷
 
 | 이름                | 값                                       |
@@ -22,7 +26,7 @@ keywords:
 | **체인 ID**         | 374                               |
 | **통화 기호**       | ETH                                       |
 | **블록 탐색기**     | https://hoodiscan.status.network       |
-| **브릿지**          | https://eth.faucet.status.network            |
+| **파우셋**          | https://eth.faucet.status.network            |
 | **WebSocket RPC**   | WebSocket RPC를 받으려면 [Telegram](https://t.me/statusl2)으로 문의하세요 |
 
 이것은 Status Network Hoodi 테스트넷의 공식 네트워크 세부정보입니다. 이 세부정보는 다음과 같은 용도로 사용할 수 있습니다:

--- a/i18n/ko/docusaurus-plugin-content-docs/current/overview/tokenomics/pre-deposits.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/overview/tokenomics/pre-deposits.md
@@ -20,6 +20,10 @@ keywords:
 
 # 사전예치
 
+:::info Status Network × Linea 합병 — 금고 참여자를 위한 안내
+[Status Network의 Linea 합병](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream) 이후에도 사전예치 금고는 전액 담보로 안전하게 유지됩니다. 지금은 별도 조치가 필요하지 않습니다. 출금 인터페이스가 열리면 **Linea Mainnet** 에서 예치금 + 누적 수익 + 유동성 보상(2,000만 SNT + 2,000만 LINEA 풀)을 청구할 수 있습니다. 출금 오픈 시 별도 공지됩니다.
+:::
+
 Status Network는 메인넷 출시 전에 유동성 확보와 초기 Karma 배포를 위한 사전예치 캠페인을 진행하고 있습니다. 두 가지 금고 시스템이 캠페인을 지원합니다:
 
 | 자산                     | 금고 제공자      | 영수증 토큰 | 네트워크         |

--- a/i18n/ko/docusaurus-plugin-content-docs/current/tools/core-infrastructure/bridge.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/tools/core-infrastructure/bridge.md
@@ -14,6 +14,10 @@ slug: '/tools/core-infrastructure/bridge'
 
 Status Network Hoodi 테스트넷 브릿지를 사용하면 Hoodi (레이어 1)와 Status Network Hoodi 테스트넷 (레이어 2) 간에 토큰을 전송하고 메시지를 전달할 수 있습니다. 브릿지 인터페이스는 [bridge.status.network](https://bridge.status.network)에서 이용할 수 있습니다.
 
+:::warning Hoodi 테스트넷 종료 — 2026년 5월 15일
+Status Network는 Linea 스택으로 합병됩니다. Hoodi 테스트넷 브릿지는 **2026년 5월 15일**에 종료됩니다. 그 전에 L2 테스트넷 ETH를 L1으로 브릿징해 주세요. 종료 후 남은 잔액은 복구할 수 없습니다. [전체 공지 보기](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream).
+:::
+
 ## 브릿지 컨트랙트
 
 ### 레이어 1 (Hoodi)

--- a/i18n/ko/docusaurus-plugin-content-docs/current/tools/core-infrastructure/testnet-faucets.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/tools/core-infrastructure/testnet-faucets.md
@@ -14,6 +14,10 @@ slug: '/tools/core-infrastructure/testnet-faucets'
 
 Status Network Hoodi 테스트넷을 시작하려면 테스트넷 ETH 또는 테스트 자산이 필요할 수 있습니다.
 
+:::warning Hoodi 테스트넷 종료 — 2026년 5월 15일
+Status Network는 Linea 스택으로 합병됩니다. 파우셋, RPC, 브릿지를 포함한 Hoodi 테스트넷 인프라는 **2026년 5월 15일**에 종료됩니다. L2 테스트넷 ETH는 그 전에 [bridge.status.network](https://bridge.status.network)에서 L1으로 되돌리세요. [전체 공지 보기](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream).
+:::
+
 ## Status Network Hoodi 테스트넷 ETH 파우셋
 
 Status Network Hoodi 테스트넷 파우셋은 [faucet.status.network](https://eth.faucet.status.network)에서 이용할 수 있습니다.

--- a/i18n/zh/code.json
+++ b/i18n/zh/code.json
@@ -545,6 +545,42 @@
     "message": "网站、社交频道和所有官方资源汇总",
     "description": "Homepage community card description for official links"
   },
+  "homepage.merger.tag": {
+    "message": "网络更新",
+    "description": "Homepage merger banner tag/eyebrow"
+  },
+  "homepage.merger.title": {
+    "message": "Status Network 正在合并至 Linea",
+    "description": "Homepage merger banner title"
+  },
+  "homepage.merger.subtitle": {
+    "message": "Hoodi 测试网（链 ID 374）将于 2026 年 5 月 15 日关闭——包括 RPC 和桥接在内的所有基础设施。",
+    "description": "Homepage merger banner subtitle"
+  },
+  "homepage.merger.testnet.heading": {
+    "message": "在 Status Network Hoodi 上持有测试网 ETH？",
+    "description": "Homepage merger CTA heading for testnet ETH holders"
+  },
+  "homepage.merger.testnet.body": {
+    "message": "请在 5 月 15 日前通过 bridge.status.network 将 L2 → L1 的资产桥接回来。关闭后 L2 测试网上的余额将无法找回。Hoodi 快照已完成，现在提款不影响 SNT + LINEA 奖励资格。",
+    "description": "Homepage merger CTA body for testnet ETH holders"
+  },
+  "homepage.merger.predeposit.heading": {
+    "message": "参与了预存款金库？",
+    "description": "Homepage merger CTA heading for pre-deposit vault holders"
+  },
+  "homepage.merger.predeposit.body": {
+    "message": "暂无需操作。金库资产完全安全。提款界面上线后，您可在 Linea 主网领取存款 + 应计收益 + SNT/LINEA 流动奖励。请关注后续公告。",
+    "description": "Homepage merger CTA body for pre-deposit vault holders"
+  },
+  "homepage.merger.action.announcement": {
+    "message": "阅读完整公告",
+    "description": "Homepage merger banner primary action label"
+  },
+  "homepage.merger.action.bridge": {
+    "message": "打开桥接",
+    "description": "Homepage merger banner secondary action label"
+  },
   "ideaCatalog.filter.category": {
     "message": "分类",
     "description": "Filter group label"

--- a/i18n/zh/code.json
+++ b/i18n/zh/code.json
@@ -1,4 +1,8 @@
 {
+  "theme.announcementBar.lineaMergerMay2026": {
+    "message": "<strong>Status Network 正在合并至 Linea。</strong>Hoodi 测试网（链 ID <strong>374</strong>）将于 <strong>2026 年 5 月 15 日</strong>关闭——请在此之前将测试网 ETH 跨回 L1。<br /><a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream\">阅读公告</a> · <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://bridge.status.network\">打开跨链桥</a>",
+    "description": "Announcement bar HTML for Status Network merging into Linea and Hoodi testnet shutdown (May 15, 2026)."
+  },
   "theme.ErrorPageContent.title": {
     "message": "页面已崩溃。",
     "description": "The title of the fallback page when the page crashed"

--- a/i18n/zh/docusaurus-plugin-content-docs/current/overview/general-info/network-details.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/overview/general-info/network-details.md
@@ -13,6 +13,10 @@ keywords:
 ---
 # 网络详情
 
+:::warning Hoodi 测试网将于 2026 年 5 月 15 日关闭
+Status Network 正在并入 Linea 技术栈。Hoodi 测试网（链 ID 374）的 RPC、跨链桥及所有基础设施将于 **2026 年 5 月 15 日**下线。如果您在 L2 上持有测试网 ETH，请务必在此日期前通过 [bridge.status.network](https://bridge.status.network) 跨回 L1。关闭后剩余余额将无法恢复。[查看完整公告](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream)。
+:::
+
 ## Status 测试网
 
 | 名称                | 值                                       |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/overview/tokenomics/pre-deposits.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/overview/tokenomics/pre-deposits.md
@@ -20,6 +20,10 @@ keywords:
 
 # 预存款
 
+:::info Status Network × Linea 合并说明（面向金库参与者）
+在 [Status Network 并入 Linea](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream) 后，预存款金库仍保持全额抵押并且安全。您现在无需任何操作。待提取界面开放后，您可在 **Linea Mainnet** 领取存款 + 累计收益 + 流动性奖励（2000 万 SNT + 2000 万 LINEA 奖励池）。提取开放时将另行公告。
+:::
+
 Status Network 正在主网启动前进行预存款活动，以引导流动性和早期 Karma 分配。两个不同的金库系统支持该活动：
 
 | 资产                     | 金库提供者       | 收据代币 | 网络             |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/tools/core-infrastructure/bridge.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/tools/core-infrastructure/bridge.md
@@ -14,6 +14,10 @@ slug: '/tools/core-infrastructure/bridge'
 
 Status Network Hoodi 测试网跨链桥允许用户在 Hoodi（第一层）和 Status Network Hoodi 测试网（第二层）之间转移代币和传递消息。跨链桥界面可在 [bridge.status.network](https://bridge.status.network) 访问。
 
+:::warning Hoodi 测试网将于 2026 年 5 月 15 日关闭
+Status Network 正在并入 Linea 技术栈。Hoodi 测试网跨链桥将于 **2026 年 5 月 15 日**关闭。请在此之前将 L2 测试网 ETH 跨回 L1；关闭后剩余余额将无法恢复。[查看完整公告](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream)。
+:::
+
 ## 跨链桥合约
 
 ### 第一层 (Hoodi)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/tools/core-infrastructure/testnet-faucets.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/tools/core-infrastructure/testnet-faucets.md
@@ -16,6 +16,10 @@ slug: '/tools/core-infrastructure/testnet-faucets'
 
 要开始在 Status Network Hoodi 测试网上进行开发，您可能需要一些测试网 ETH 或测试资产。
 
+:::warning Hoodi 测试网将于 2026 年 5 月 15 日关闭
+Status Network 正在并入 Linea 技术栈。包括水龙头、RPC 和跨链桥在内的 Hoodi 测试网基础设施将于 **2026 年 5 月 15 日**下线。请在此之前通过 [bridge.status.network](https://bridge.status.network) 将 L2 测试网 ETH 跨回 L1。[查看完整公告](https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream)。
+:::
+
 ## Status Network Hoodi 测试网 ETH 水龙头
 
 Status Network Hoodi 测试网水龙头可在 [faucet.status.network](https://eth.faucet.status.network) 访问。

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -595,6 +595,26 @@ div[class*='sidebarViewport'] {
   font-size: 0.9rem;
 }
 
+/* Announcement Bar — larger, more prominent */
+[class*='announcementBar'] {
+  font-size: 1rem !important;
+  font-weight: 500 !important;
+  padding: 0.6rem 1rem !important;
+  min-height: 2.75rem !important;
+}
+
+[class*='announcementBarContent'] {
+  font-size: 1rem !important;
+  line-height: 1.5 !important;
+}
+
+[class*='announcementBarContent'] a {
+  color: #ffffff !important;
+  font-weight: 600 !important;
+  text-decoration: underline !important;
+  text-underline-offset: 2px !important;
+}
+
 /* Footer Enhancements */
 .footer {
   background: rgba(var(--page-background-rgb), 0.95) !important;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -599,8 +599,16 @@ div[class*='sidebarViewport'] {
 [class*='announcementBar'] {
   font-size: 1rem !important;
   font-weight: 500 !important;
-  padding: 0.6rem 1rem !important;
+  padding: 16px 16px !important;
   min-height: 2.75rem !important;
+
+  @media screen and (min-width: 768px) {
+    padding: 10px 16px !important;
+  }
+
+  @media screen and (min-width: 992px) {
+    padding: 40px 16px !important;
+  }
 }
 
 [class*='announcementBarContent'] {

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -1,3 +1,122 @@
+/* Merger Banner — full-width strip */
+.mergerBanner {
+  width: 100%;
+  background: rgba(245, 158, 11, 0.1);
+  border-bottom: 1px solid rgba(245, 158, 11, 0.3);
+  padding: 0.75rem 2rem;
+}
+
+[data-theme='dark'] .mergerBanner {
+  background: rgba(245, 158, 11, 0.08);
+  border-bottom-color: rgba(245, 158, 11, 0.22);
+}
+
+.mergerBannerContent {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem 0.75rem;
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.mergerBannerTag {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #d97706;
+  background: rgba(245, 158, 11, 0.15);
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+[data-theme='dark'] .mergerBannerTag {
+  color: #fbbf24;
+  background: rgba(245, 158, 11, 0.12);
+}
+
+.mergerBannerTitle {
+  font-weight: 600;
+  color: #09101c;
+  flex-shrink: 0;
+}
+
+[data-theme='dark'] .mergerBannerTitle {
+  color: #ffffff;
+}
+
+.mergerBannerItems {
+  display: contents;
+}
+
+.mergerBannerItem {
+  color: var(--status-gray-600);
+}
+
+[data-theme='dark'] .mergerBannerItem {
+  color: var(--status-gray-400);
+}
+
+.mergerBannerSep {
+  color: var(--status-gray-400);
+  flex-shrink: 0;
+}
+
+.mergerBannerBreak {
+  flex-basis: 100%;
+  width: 0;
+  height: 0;
+}
+
+.mergerBannerLinks {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.mergerBannerLink {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: #7140fd !important;
+  text-decoration: none !important;
+  white-space: nowrap;
+  transition: opacity 150ms ease;
+}
+
+[data-theme='dark'] .mergerBannerLink {
+  color: #9b7aff !important;
+}
+
+.mergerBannerLink:hover {
+  opacity: 0.75;
+  text-decoration: none !important;
+}
+
+@media (max-width: 768px) {
+  .mergerBannerContent {
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .mergerBannerLinks {
+    margin-left: 0;
+  }
+
+  .mergerBannerSep {
+    display: none;
+  }
+
+  .mergerBannerItem {
+    display: block;
+  }
+}
+
 /* Hero Section */
 .hero {
   padding: 4rem 2rem 2rem;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -117,6 +117,64 @@ function getCommunityLinks() {
   ];
 }
 
+function MergerBanner() {
+  return (
+    <div className={styles.mergerBanner}>
+      <div className={styles.mergerBannerContent}>
+        <span className={styles.mergerBannerTag}>
+          <Translate id="homepage.merger.tag" description="Homepage merger banner tag/eyebrow">
+            Important migration update
+          </Translate>
+        </span>
+        <span className={styles.mergerBannerTitle}>
+          <Translate id="homepage.merger.title" description="Homepage merger banner title">
+            Status Network is merging into the Linea stack.
+          </Translate>
+        </span>
+        <span className={styles.mergerBannerBreak} aria-hidden="true" />
+        <span className={styles.mergerBannerItems}>
+          <span className={styles.mergerBannerItem}>
+            <Translate id="homepage.merger.testnet.heading" description="Homepage merger CTA heading for testnet ETH holders">
+              If you have testnet ETH on Status Network Hoodi:
+            </Translate>
+            {' '}
+            <Translate id="homepage.merger.testnet.body" description="Homepage merger CTA body for testnet ETH holders">
+              Withdraw by May 15 by bridging L2 → L1 at bridge.status.network. Hoodi (chain ID 374) RPC and bridge shut down on May 15, and any L2 balance left after that is unrecoverable. The Hoodi snapshot is already taken, so withdrawing now does not affect SNT + LINEA reward eligibility.
+            </Translate>
+          </span>
+          <span className={styles.mergerBannerBreak} aria-hidden="true" />
+          <span className={styles.mergerBannerItem}>
+            <Translate id="homepage.merger.predeposit.heading" description="Homepage merger CTA heading for pre-deposit vault holders">
+              If you participated in pre-deposit vaults (ETH / GUSD / SNT / LINEA):
+            </Translate>
+            {' '}
+            <Translate id="homepage.merger.predeposit.body" description="Homepage merger CTA body for pre-deposit vault holders">
+              No action is needed yet. Vaults remain fully backed and safe. When withdrawals open, claim your deposits + accrued yield + liquid rewards from the 20M SNT + 20M LINEA pool on Linea Mainnet via the claim interface.
+            </Translate>
+          </span>
+          <span className={styles.mergerBannerBreak} aria-hidden="true" />
+          <span className={styles.mergerBannerBreak} aria-hidden="true" />
+        </span>
+        <span className={styles.mergerBannerLinks}>
+          <Link
+            to="https://status.network/blog/status-network-merges-with-linea-scaling-gasless-privacy-upstream"
+            className={styles.mergerBannerLink}
+          >
+            <Translate id="homepage.merger.action.announcement" description="Homepage merger banner primary action label">
+              Read announcement
+            </Translate>{' '}→
+          </Link>
+          <Link to="https://bridge.status.network" className={styles.mergerBannerLink}>
+            <Translate id="homepage.merger.action.bridge" description="Homepage merger banner secondary action label">
+              Open bridge
+            </Translate>{' '}→
+          </Link>
+        </span>
+      </div>
+    </div>
+  );
+}
+
 function Hero() {
   const logoSrc = useBaseUrl('/img/sn_logo.svg');
   return (
@@ -287,6 +345,7 @@ export default function Home(): React.JSX.Element {
         description: 'Homepage layout description',
       })}
     >
+      <MergerBanner />
       <Hero />
       <DocCards />
       <QuickStart />

--- a/src/theme/AnnouncementBar/Content/index.tsx
+++ b/src/theme/AnnouncementBar/Content/index.tsx
@@ -1,0 +1,28 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {useThemeConfig} from '@docusaurus/theme-common';
+import styles from './styles.module.css';
+
+type Props = React.ComponentPropsWithoutRef<'div'>;
+
+export default function AnnouncementBarContent(props: Props): ReactNode {
+  const {announcementBar} = useThemeConfig();
+  if (!announcementBar?.content) {
+    return null;
+  }
+  const html = translate({
+    id: 'theme.announcementBar.lineaMergerMay2026',
+    message: announcementBar.content,
+    description:
+      'Announcement bar HTML for Status Network merging into Linea and Hoodi testnet shutdown (May 15, 2026).',
+  });
+  return (
+    <div
+      {...props}
+      className={clsx(styles.content, props.className)}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{__html: html}}
+    />
+  );
+}

--- a/src/theme/AnnouncementBar/Content/styles.module.css
+++ b/src/theme/AnnouncementBar/Content/styles.module.css
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.content {
+  font-size: 85%;
+  text-align: center;
+  padding: 5px 0;
+}
+
+.content a {
+  color: inherit;
+  text-decoration: underline;
+}


### PR DESCRIPTION
# What does this PR resolve? 🚀
- Hoodi testnet shutdown and Status Network–Linea merger updates across EN docs (network details, pre-deposits, bridge, faucets)
- Mirrored localized docs and i18n strings (ja, ko, zh)
- Docusaurus announcement bar with themed custom Content for merger messaging
- Homepage merger banner component, styles, and related CSS

# Details 📝
Brings the docs site in line with the testnet transition and merger narrative for readers in all configured locales.

# Checklist ✅
- [ ] I have merged the main branch into my branch and resolved all conflicts
- [ ] I have documented the new code
- [ ] I have smoke tested the new code locally
- [ ] I have assigned the PR to myself
- [ ] I have named the PR correctly

Made with [Cursor](https://cursor.com)